### PR TITLE
～～ FilterType が両方存在しないとエラーになる問題を修正

### DIFF
--- a/main.go
+++ b/main.go
@@ -169,10 +169,10 @@ func validateSearchCourseOptions(courseName string, courseNameFilterType string,
 	if !util.Contains(allowedFilterType, filterType) {
 		return searchCourseOptions{}, fmt.Errorf("filterType error: %s, %+v", filterType, allowedFilterType)
 	}
-	if !util.Contains(allowedFilterType, courseNameFilterType) {
+	if courseName != "" && !util.Contains(allowedFilterType, courseNameFilterType) {
 		return searchCourseOptions{}, fmt.Errorf("courseNameFilterType error: %s, %+v", courseNameFilterType, allowedFilterType)
 	}
-	if !util.Contains(allowedFilterType, courseOverviewFilterType) {
+	if courseOverview != "" && !util.Contains(allowedFilterType, courseOverviewFilterType) {
 		return searchCourseOptions{}, fmt.Errorf("courseOverviewFilterType error: %s, %+v", courseOverviewFilterType, allowedFilterType)
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -88,6 +88,28 @@ func Test_validateSearchCourseOptions(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "courseName: not exist",
+			args: args{
+				courseName:               "",
+				courseNameFilterType:     "",
+				courseOverview:           "科学",
+				courseOverviewFilterType: "and",
+				filterType:               "and",
+				limit:                    "100",
+				offset:                   "50",
+			},
+			want: searchCourseOptions{
+				courseName:               "",
+				courseNameFilterType:     "",
+				courseOverview:           "科学",
+				courseOverviewFilterType: "and",
+				filterType:               "and",
+				limit:                    100,
+				offset:                   50,
+			},
+			wantErr: false,
+		},
+		{
 			name: "courseOverviewFilterType: invalid",
 			args: args{
 				courseName:               "情報",
@@ -114,6 +136,28 @@ func Test_validateSearchCourseOptions(t *testing.T) {
 			},
 			want:    searchCourseOptions{},
 			wantErr: true,
+		},
+		{
+			name: "courseOverview: not exist",
+			args: args{
+				courseName:               "情報",
+				courseNameFilterType:     "and",
+				courseOverview:           "",
+				courseOverviewFilterType: "",
+				filterType:               "and",
+				limit:                    "100",
+				offset:                   "50",
+			},
+			want: searchCourseOptions{
+				courseName:               "情報",
+				courseNameFilterType:     "and",
+				courseOverview:           "",
+				courseOverviewFilterType: "",
+				filterType:               "and",
+				limit:                    100,
+				offset:                   50,
+			},
+			wantErr: false,
 		},
 		{
 			name: "filterType: invalid",


### PR DESCRIPTION
- `course_name` もしくは `course_overview` のどちらかで検索したときに、`course_name_filter_type`, `course_overview_filter_type` の両方が存在しないと不正なリクエストになる問題を修正
  -  正規になるべきたが不正になってしまっていたものの例：`/course?course_overview=keyword&course_overview_filter_type=keyword&filter_type=and`