### PR TITLE
検索条件にヒットするものがなかったとき、レスポンスとして `null` ではなく `[]` を返すように

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -52,7 +52,7 @@ func courseSimpleSearchHandler(w http.ResponseWriter, r *http.Request) {
 
 	// CourseDB -> CourseJSON
 	// TODO: わざわざ2つ定義しているのは面倒なのでひとつにしたい
-	var coursesJSON []CourseJSON
+	coursesJSON := []CourseJSON{}
 	for _, c := range courses {
 
 		var term []int


### PR DESCRIPTION
- 検索条件にヒットするものがなかったとき、レスポンスとして `null` が返ってきてしまっていた
  - https://github.com/sylms/daifuku/pull/12 のときに不便だったし、https://github.com/sylms/azuki-api に従っていないので修正
  - `[]` が返ってくるようにした